### PR TITLE
Issue #3: Get redwood to watch for changes in /packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "private": true,
+  "scripts": {
+    "build:oauth2-server": "babel packages/oauth2-server -d packages/oauth2-server/dist --copy-files",
+    "build:watch": "nodemon --watch packages --ext \"js,ts,tsx\" --ignore packages/oauth2-server/dist --exec \"yarn --cwd packages/oauth2-server build:oauth2-server && yarn rw dev\""
+  },
   "workspaces": {
     "packages": [
       "api",


### PR DESCRIPTION
This PR closes #3 

### Description
Created two new scripts in the root `package.json`:
- Running `yarn build:watch` will run the dev server while allowing the main application to watch the packages directory and when a change is detected (dist is excluded) a new build of the `oauth2-server` package will be run and the dev server will restart (`yarn rw dev` will be run)
- the `build:oauth2-server` script is used by `build:watch` to rebuild the `oauth2-server` package but it can also be run on its own so that users don't have to cd into the `oauth2-server` package to build it

### Screenshots

When running `yarn build:watch` in the root directory Babel will compile the files in the `oauth2-server` package and then the dev server will start 

<img width="769" alt="new build" src="https://user-images.githubusercontent.com/47253537/213012025-46381606-6497-43a0-8ed3-d7460a17d440.png">

Demo of changing a file in `/packages` and a new build being run

https://user-images.githubusercontent.com/47253537/213012195-e7c0ffe0-b665-44fc-8038-cd87a200784d.mov





### Checklist
- [X] Fix all lint + build issues with CI
- [X] Request a review
