### PR TITLE
Issues #4 & #5: enable additional payload fields (client_uri, client_name, etc.)

### DIFF
--- a/api/src/graphql/oidc.sdl.js
+++ b/api/src/graphql/oidc.sdl.js
@@ -9,7 +9,15 @@ export const schema = gql`
 
   type Mutation {
     createClient: Oidc! @requireAuth
-    updateClient(id: String!, redirectUrls: String!, clientURI: String!, clientName: String!, tosURI: String!, logoURI: String!, policyURI: String!): Oidc! @requireAuth
+    updateClient(
+      id: String!
+      redirectUrls: String!
+      clientURI: String!
+      clientName: String!
+      tosURI: String!
+      logoURI: String!
+      policyURI: String!
+    ): Oidc! @requireAuth
     deleteClient(id: String!): Oidc! @requireAuth
   }
 

--- a/api/src/graphql/oidc.sdl.js
+++ b/api/src/graphql/oidc.sdl.js
@@ -9,7 +9,7 @@ export const schema = gql`
 
   type Mutation {
     createClient: Oidc! @requireAuth
-    updateClient(id: String!, redirectUrls: String!): Oidc! @requireAuth
+    updateClient(id: String!, redirectUrls: String!, clientURI: String!, clientName: String!, tosURI: String!, logoURI: String!, policyURI: String!): Oidc! @requireAuth
     deleteClient(id: String!): Oidc! @requireAuth
   }
 

--- a/api/src/graphql/oidc.sdl.js
+++ b/api/src/graphql/oidc.sdl.js
@@ -12,11 +12,11 @@ export const schema = gql`
     updateClient(
       id: String!
       redirectUrls: String!
-      clientURI: String!
-      clientName: String!
-      tosURI: String!
-      logoURI: String!
-      policyURI: String!
+      clientURI: String
+      clientName: String
+      tosURI: String
+      logoURI: String
+      policyURI: String
     ): Oidc! @requireAuth
     deleteClient(id: String!): Oidc! @requireAuth
   }

--- a/api/src/services/clients/clients.js
+++ b/api/src/services/clients/clients.js
@@ -48,7 +48,7 @@ export const createClient = async () => {
   return client
 }
 
-export const updateClient = async ({ id, redirectUrls }) => {
+export const updateClient = async ({ id, redirectUrls, clientURI, clientName, tosURI, logoURI, policyURI }) => {
   const client = await db.oidc.findUnique({
     where: { id_type: { id, type: 7 } },
     select: { developers: true, payload: true },
@@ -60,7 +60,13 @@ export const updateClient = async ({ id, redirectUrls }) => {
   // TODO validate list as https urls, or http for localhost
   return db.oidc.update({
     where: { id_type: { id, type: 7 } },
-    data: { payload: { ...client.payload, redirect_uris: list } },
+    data: { payload: { ...client.payload,
+        client_uri: clientURI,
+        client_name: clientName,
+        tos_uri: tosURI,
+        logo_uri: logoURI,
+        policy_uri: policyURI,
+        redirect_uris: list } },
   })
 }
 

--- a/api/src/services/clients/clients.js
+++ b/api/src/services/clients/clients.js
@@ -48,7 +48,15 @@ export const createClient = async () => {
   return client
 }
 
-export const updateClient = async ({ id, redirectUrls, clientURI, clientName, tosURI, logoURI, policyURI }) => {
+export const updateClient = async ({
+  id,
+  redirectUrls,
+  clientURI,
+  clientName,
+  tosURI,
+  logoURI,
+  policyURI,
+}) => {
   const client = await db.oidc.findUnique({
     where: { id_type: { id, type: 7 } },
     select: { developers: true, payload: true },
@@ -60,13 +68,17 @@ export const updateClient = async ({ id, redirectUrls, clientURI, clientName, to
   // TODO validate list as https urls, or http for localhost
   return db.oidc.update({
     where: { id_type: { id, type: 7 } },
-    data: { payload: { ...client.payload,
+    data: {
+      payload: {
+        ...client.payload,
         client_uri: clientURI,
         client_name: clientName,
         tos_uri: tosURI,
         logo_uri: logoURI,
         policy_uri: policyURI,
-        redirect_uris: list } },
+        redirect_uris: list,
+      },
+    },
   })
 }
 

--- a/api/src/services/clients/clients.js
+++ b/api/src/services/clients/clients.js
@@ -71,11 +71,11 @@ export const updateClient = async ({
     data: {
       payload: {
         ...client.payload,
-        client_uri: clientURI,
-        client_name: clientName,
-        tos_uri: tosURI,
-        logo_uri: logoURI,
-        policy_uri: policyURI,
+        ...(clientURI && { client_uri: clientURI }),
+        ...(clientName && { client_name: clientName }),
+        ...(tosURI && { tos_uri: tosURI }),
+        ...(logoURI && { logo_uri: logoURI }),
+        ...(policyURI && { policy_uri: policyURI }),
         redirect_uris: list,
       },
     },

--- a/api/src/services/oAuth/oAuth.test.js
+++ b/api/src/services/oAuth/oAuth.test.js
@@ -1,6 +1,7 @@
-import { oAuthUrl, codeGrant } from './oAuth'
 import { COINBASE } from 'src/lib/oAuth/providers/coinbase'
 import { PLAID, getSandboxPublicToken } from 'src/lib/oAuth/providers/plaid'
+
+import { oAuthUrl, codeGrant } from './oAuth'
 jest.setTimeout(60000)
 
 /* eslint-disable no-console */

--- a/web/src/components/LoadingDots/LoadingDots.js
+++ b/web/src/components/LoadingDots/LoadingDots.js
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { useSpring, animated } from 'react-spring'
 
 // <AnimationLoop reset native config={{ duration: 2000 }}>

--- a/web/src/components/OidcCell/OidcCell.js
+++ b/web/src/components/OidcCell/OidcCell.js
@@ -27,11 +27,11 @@ const UPDATE_ClIENT = gql`
   mutation UpdateClientMutation(
     $id: String!
     $redirectUrls: String!
-    $clientURI: String!
-    $clientName: String!
-    $tosURI: String!
-    $logoURI: String!
-    $policyURI: String!
+    $clientURI: String
+    $clientName: String
+    $tosURI: String
+    $logoURI: String
+    $policyURI: String
   ) {
     updateClient(
       id: $id
@@ -54,7 +54,7 @@ export const Success = ({ clients }) => {
     },
     onError: (error) => {
       toast.error(error.message)
-    }
+    },
   })
 
   const onSubmit = (data) => {
@@ -95,51 +95,31 @@ export const Success = ({ clients }) => {
             <Label name="clientURI" errorClassName="error">
               Client Uri
             </Label>
-            <TextField
-              name="clientURI"
-              errorClassName="error"
-              validation={{ required: true }}
-            />
+            <TextField name="clientURI" errorClassName="error" />
             <FieldError name="clientURI" className="error" />
             <br />
             <Label name="clientName" errorClassName="error">
               Client Name
             </Label>
-            <TextField
-              name="clientName"
-              errorClassName="error"
-              validation={{ required: true }}
-            />
+            <TextField name="clientName" errorClassName="error" />
             <FieldError name="clientName" className="error" />
             <br />
             <Label name="tosURI" errorClassName="error">
               TOS Uri
             </Label>
-            <TextField
-              name="tosURI"
-              errorClassName="error"
-              validation={{ required: true }}
-            />
+            <TextField name="tosURI" errorClassName="error" />
             <FieldError name="tosURI" className="error" />
             <br />
             <Label name="logoURI" errorClassName="error">
               Logo Uri
             </Label>
-            <TextField
-              name="logoURI"
-              errorClassName="error"
-              validation={{ required: true }}
-            />
+            <TextField name="logoURI" errorClassName="error" />
             <FieldError name="logoURI" className="error" />
             <br />
             <Label name="policyURI" errorClassName="error">
               Policy Uri
             </Label>
-            <TextField
-              name="policyURI"
-              errorClassName="error"
-              validation={{ required: true }}
-            />
+            <TextField name="policyURI" errorClassName="error" />
             <FieldError name="policyURI" className="error" />
             <br />
             <Submit disabled={loading}>Update</Submit>

--- a/web/src/components/OidcCell/OidcCell.js
+++ b/web/src/components/OidcCell/OidcCell.js
@@ -1,12 +1,4 @@
-import {
-  FieldError,
-  Form,
-  Label,
-  TextField,
-  TextAreaField,
-  Submit,
-} from '@redwoodjs/forms'
-import { MetaTags } from '@redwoodjs/web'
+import { FieldError, Form, Label, TextField, Submit } from '@redwoodjs/forms'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
@@ -30,19 +22,39 @@ export const Failure = ({ error }) => (
   <div style={{ color: 'red' }}>Error: {error?.message}</div>
 )
 
+/* eslint-disable-next-line camelcase */
 const UPDATE_ClIENT = gql`
-  mutation UpdateClientMutation($id: String!, $redirectUrls: String!, $clientURI: String!, $clientName: String!, $tosURI: String!, $logoURI: String!, $policyURI: String!) {
-    updateClient(id: $id, redirectUrls: $redirectUrls, clientURI: $clientURI, clientName: $clientName, tosURI: $tosURI, logoURI: $logoURI, policyURI: $policyURI) {
+  mutation UpdateClientMutation(
+    $id: String!
+    $redirectUrls: String!
+    $clientURI: String!
+    $clientName: String!
+    $tosURI: String!
+    $logoURI: String!
+    $policyURI: String!
+  ) {
+    updateClient(
+      id: $id
+      redirectUrls: $redirectUrls
+      clientURI: $clientURI
+      clientName: $clientName
+      tosURI: $tosURI
+      logoURI: $logoURI
+      policyURI: $policyURI
+    ) {
       id
     }
   }
 `
 
 export const Success = ({ clients }) => {
-  const [updateClient, { loading, error }] = useMutation(UPDATE_ClIENT, {
+  const [updateClient, { loading }] = useMutation(UPDATE_ClIENT, {
     onCompleted: () => {
       toast.success('Client updated!')
     },
+    onError: (error) => {
+      toast.error(error.message)
+    }
   })
 
   const onSubmit = (data) => {

--- a/web/src/components/OidcCell/OidcCell.js
+++ b/web/src/components/OidcCell/OidcCell.js
@@ -31,8 +31,8 @@ export const Failure = ({ error }) => (
 )
 
 const UPDATE_ClIENT = gql`
-  mutation UpdateClientMutation($id: String!, $redirectUrls: String!) {
-    updateClient(id: $id, redirectUrls: $redirectUrls) {
+  mutation UpdateClientMutation($id: String!, $redirectUrls: String!, $clientURI: String!, $clientName: String!, $tosURI: String!, $logoURI: String!, $policyURI: String!) {
+    updateClient(id: $id, redirectUrls: $redirectUrls, clientURI: $clientURI, clientName: $clientName, tosURI: $tosURI, logoURI: $logoURI, policyURI: $policyURI) {
       id
     }
   }
@@ -49,6 +49,8 @@ export const Success = ({ clients }) => {
     console.log(data)
     updateClient({ variables: data })
   }
+
+  console.log(clients)
 
   return (
     <div>
@@ -77,6 +79,57 @@ export const Success = ({ clients }) => {
               validation={{ required: true }}
             />
             <FieldError name="redirectUrls" className="error" />
+            <br />
+            <Label name="clientURI" errorClassName="error">
+              Client Uri
+            </Label>
+            <TextField
+              name="clientURI"
+              errorClassName="error"
+              validation={{ required: true }}
+            />
+            <FieldError name="clientURI" className="error" />
+            <br />
+            <Label name="clientName" errorClassName="error">
+              Client Name
+            </Label>
+            <TextField
+              name="clientName"
+              errorClassName="error"
+              validation={{ required: true }}
+            />
+            <FieldError name="clientName" className="error" />
+            <br />
+            <Label name="tosURI" errorClassName="error">
+              TOS Uri
+            </Label>
+            <TextField
+              name="tosURI"
+              errorClassName="error"
+              validation={{ required: true }}
+            />
+            <FieldError name="tosURI" className="error" />
+            <br />
+            <Label name="logoURI" errorClassName="error">
+              Logo Uri
+            </Label>
+            <TextField
+              name="logoURI"
+              errorClassName="error"
+              validation={{ required: true }}
+            />
+            <FieldError name="logoURI" className="error" />
+            <br />
+            <Label name="policyURI" errorClassName="error">
+              Policy Uri
+            </Label>
+            <TextField
+              name="policyURI"
+              errorClassName="error"
+              validation={{ required: true }}
+            />
+            <FieldError name="policyURI" className="error" />
+            <br />
             <Submit disabled={loading}>Update</Submit>
           </Form>
         </div>

--- a/web/src/components/OidcCell/OidcCell.test.js
+++ b/web/src/components/OidcCell/OidcCell.test.js
@@ -1,4 +1,5 @@
 import { render } from '@redwoodjs/testing/web'
+
 import { Loading, Empty, Failure, Success } from './OidcCell'
 import { standard } from './OidcCell.mock'
 


### PR DESCRIPTION
This PR closes #14 
This PR closes #15 

### Description
- Added backend logic to allow for updating client_uri, client_name, tos_uri, logo_uri, policy_uri
- Added frontend forms to allow for updating the above values via the UI and added error toast popup on failure
- Pushed separate commit with lint fixes

### Screenshots
Filling in form info 

<img width="1051" alt="filling in info" src="https://user-images.githubusercontent.com/47253537/213300109-cb895d96-e299-4bdd-9b1b-e88eda89b818.png">

Successful update

<img width="1375" alt="updated" src="https://user-images.githubusercontent.com/47253537/213300234-15f6e820-7480-4ce5-b18c-e935eb96617a.png">

Failure toast message

<img width="1398" alt="failure" src="https://user-images.githubusercontent.com/47253537/213300275-056ede50-7eb8-494d-8912-3c2f58cefd1c.png">


### Checklist
- [X] Fix all lint + build issues with CI
- [X] Request a review
