### PR TITLE
Issue #17: Authorize display scopes and client metadata

### DIFF
--- a/web/src/pages/AuthorizePage/AuthorizePage.js
+++ b/web/src/pages/AuthorizePage/AuthorizePage.js
@@ -1,24 +1,85 @@
+import { useEffect, useState } from 'react'
+
+import { useAuth } from '@redwoodjs/auth'
 import { MetaTags } from '@redwoodjs/web'
 
 import { useOAuthAuthority } from 'src/providers/oAuthAuthority'
 
 const AuthorizePage = () => {
+  const [client, setClient] = useState({})
+  const [scopes, setScopes] = useState([])
+  const { currentUser } = useAuth()
   const { continueInteraction } = useOAuthAuthority()
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search)
+    setClient({
+      name: searchParams.get('clientName'),
+      logoUri: searchParams.get('clientLogoUri'),
+      policyUri: searchParams.get('clientPolicyUri'),
+      tosUri: searchParams.get('clientTosUri'),
+    })
+    searchParams.get('scope') && setScopes(searchParams.get('scope').split(','))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <>
       <MetaTags title="Authorize" description="Authorize page" />
-
-      <h1>Authorize</h1>
-      <p>Approve this app to access your account</p>
-      <p>
-        <button onClick={() => continueInteraction({ type: 'confirm' })}>
-          Confirm
-        </button>
-        <button onClick={() => continueInteraction({ type: 'abort' })}>
-          Cancel
-        </button>
-      </p>
+      <div>
+        <div>
+          <div>
+            <div>{currentUser?.username}</div>
+          </div>
+          <br />
+          <div>
+            <div>This app wants the following permissions:</div>
+            <br />
+            <div>
+              {client.logoUri && (
+                <div>
+                  <img src={client.logoUri} alt={client.name} />
+                </div>
+              )}
+              <div>{client.name && <div>{client.name}</div>}</div>
+            </div>
+            <br />
+          </div>
+          <div>
+            Scopes:
+            <ul>
+              {scopes.map((scope) => (
+                <li key={scope}>{scope}</li>
+              ))}
+            </ul>
+          </div>
+          <br />
+          <div>
+            <button onClick={() => continueInteraction({ type: 'abort' })}>
+              Cancel
+            </button>
+            <button onClick={() => continueInteraction({ type: 'confirm' })}>
+              Confirm
+            </button>
+          </div>
+          <br />
+          <div>
+            By clicking Confirm, you allow this app and Keyp to use your
+            information in accordance with their respective{' '}
+            {client.tosUri ? (
+              <a href={client.tosUri}>terms</a>
+            ) : (
+              <div>terms</div>
+            )}{' '}
+            and{' '}
+            {client.policyUri ? (
+              <a href={client.policyUri}>privacy policies.</a>
+            ) : (
+              <div>privacy policies.</div>
+            )}
+          </div>
+        </div>
+      </div>
     </>
   )
 }


### PR DESCRIPTION
Closes #17 

## Description
- Brought over the consent interaction page from keyp-app to oauth2-server-redwood and deleted Tailwind styling
- Parses and displays scopes, clientLogoUri, clientPolicyUri, clientTosUri, and clientName from URL

## Screenshots
Desktop

<img width="1116" alt="desktop" src="https://user-images.githubusercontent.com/47253537/214134743-fa4a0618-512b-4b86-826b-e88c81840f3c.png">

Demo

https://user-images.githubusercontent.com/47253537/214135317-cd980ed9-9c79-4748-af1b-e5fd759d1219.mov

### Checklist
- [X] Fix all lint + build issues with CI
- [X] Request a review

