### PR TITLE
Issue #31: Include the redirectUrl in /authorize searchParams

### DIFF
--- a/api/src/functions/oauth/middlewares/middlewares.js
+++ b/api/src/functions/oauth/middlewares/middlewares.js
@@ -1,4 +1,5 @@
 // See https://github.com/panva/node-oidc-provider/blob/v7.x/docs/README.md#pre--and-post-middlewares
+// eslint-disable-next-line no-unused-vars
 const middlewares = (oidc) => async (ctx, next) => {
   // PRE MIDDLEWARE
   await next()

--- a/packages/oauth2-server/src/index.js
+++ b/packages/oauth2-server/src/index.js
@@ -51,6 +51,12 @@ const app = (db, settings) => {
         const client = await oidc.Client.find(params.client_id)
         const provider =
           req.apiGateway?.event?.queryStringParameters?.login_provider
+        const clientRedirectUri = details?.params?.redirect_uri;
+
+        if (!client.redirectUris.includes(clientRedirectUri)) {
+          throw new Error('redirect_uri did not match any of the registered uris')
+        }
+
         if (prompt.name === 'login') {
           if (provider) {
             const response = await fetch(`${settings.REDWOOD_API_URL}/auth`, {
@@ -79,8 +85,7 @@ const app = (db, settings) => {
         client.logoUri && (path += `&clientLogoUri=${client.logoUri}`)
         client.policyUri && (path += `&clientPolicyUri=${client.policyUri}`)
         client.tosUri && (path += `&clientTosUri=${client.tosUri}`)
-        client.redirectUris &&
-          (path += `&clientRedirectUri=${client.redirectUris[0]}`)
+        path += `&clientRedirectUri=${encodeURIComponent(clientRedirectUri)}`
 
         // For more client metadata available see https://github.com/panva/node-oidc-provider/blob/main/lib/consts/client_attributes.js
 

--- a/web/src/components/ClientCell/ClientCell.js
+++ b/web/src/components/ClientCell/ClientCell.js
@@ -16,6 +16,7 @@ export const QUERY = gql`
   }
 `
 
+// eslint-disable-next-line camelcase
 const CREATE_ClIENT = gql`
   mutation CreateClientMutation {
     createClient {

--- a/web/src/components/URLRedirects/URLRedirects.js
+++ b/web/src/components/URLRedirects/URLRedirects.js
@@ -7,6 +7,7 @@ import Button from 'src/components/Button/Button'
 import { QUERY as clientQuery } from 'src/components/ClientCell'
 import TextInput from 'src/components/TextInput/TextInput'
 
+// eslint-disable-next-line camelcase
 const UPDATE_ClIENT = gql`
   mutation UpdateClientMutation($id: String!, $redirectUrls: String!) {
     updateClient(id: $id, redirectUrls: $redirectUrls) {

--- a/web/src/pages/AuthorizePage/AuthorizePage.js
+++ b/web/src/pages/AuthorizePage/AuthorizePage.js
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react'
 import { useAuth } from '@redwoodjs/auth'
 
 import Button from 'src/components/Button'
-import Icon from 'src/components/Icon'
 import { useOAuthAuthority } from 'src/providers/oAuthAuthority'
 
 function Authorize() {


### PR DESCRIPTION
Closes #31 

## Description
- we can get the redirect URI from the details of the oidc.interactionDetails, and then validate it against the client's valid redirect URIs in the DB 
- I encode the redirect URI before adding it to the URL because having a URL in a URL can cause an unintentional redirection and be potentially malicious--it also doesn't affect behavior when we encode it because JS parses the encoded URI automatically on the /authorize page (see screenshot)
- Added some lint fixes

To get this repo working I had to changed redwood.toml and the nginx config to match that of keyp-app's. do you want me to push those changes as well?

# Screenshots

logging in works (note I log the encoded /authorize page redirect uri to the console and it's correct)

https://github.com/UseKeyp/oauth2-server-redwood/assets/47253537/b01b8589-aca3-4f8a-b0d7-8affb5110af7

changing the authorized URIs in oauth.js for the dev portal to the incorrect one throws an error

https://github.com/UseKeyp/oauth2-server-redwood/assets/47253537/bbc64b45-42b5-4220-a415-53a5d65e7f05




